### PR TITLE
Make this a taskcluster-like project

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-taskcluster"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
-dist/
+.test/
+lib/
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "json parameterization module inspired from json-parameterization",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "babel src --presets babel-preset-es2015 --out-dir dist -s",
-    "test": "npm run build && mocha --ui tdd ./dist/tests.js",
-    "prepublish": "npm run build && mocha --ui tdd ./dist/tests.js"
+    "compile": "babel-compile -p es2015 src:lib test:.test",
+    "pretest": "npm run compile",
+    "test": "mocha --ui tdd .test/tests.js",
+    "prepublish": "npm run compile && mocha --ui tdd .test/tests.js"
   },
+  "files": [
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/hammad13060/json-e.git"
@@ -20,7 +24,7 @@
     "notevil": "^1.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.18.0",
+    "babel-compile": "^2.0.0",
     "babel-preset-es2015": "^6.18.0",
     "mocha": "^3.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "mocha-eslint": "^3.0.1"
   },
   "engines": {
-    "node": "0.12.x",
-    "npm": "2.7.x"
+    "node": "6.4.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "babel-compile -p es2015 src:lib test:.test",
     "pretest": "npm run compile",
-    "test": "mocha --ui tdd .test/tests.js",
+    "test": "mocha --ui tdd .test/lint.js .test/tests.js",
     "prepublish": "npm run compile && mocha --ui tdd .test/tests.js"
   },
   "files": [
@@ -26,7 +26,10 @@
   "devDependencies": {
     "babel-compile": "^2.0.0",
     "babel-preset-es2015": "^6.18.0",
-    "mocha": "^3.2.0"
+    "eslint-config-taskcluster": "^2.0.0",
+    "eslint-plugin-taskcluster": "^1.0.2",
+    "mocha": "^3.2.0",
+    "mocha-eslint": "^3.0.1"
   },
   "engines": {
     "node": "0.12.x",

--- a/src/index.js
+++ b/src/index.js
@@ -1,166 +1,163 @@
-var safeEval = require("notevil")
-var _ = require("lodash");
+var safeEval = require('notevil');
+var _ = require('lodash');
 
 class Parameterize {
-	
-	constructor(template, context) {
-		this.template = _.clone(template);
-		this.context = context;
-	}
+  
+  constructor(template, context) {
+    this.template = _.clone(template);
+    this.context = context;
+  }
 
-	/* private */
-	_attachArrayAccessor(context) {
-		for (var key in context) {
-			if (context.hasOwnProperty(key)) {
-				
-				var value = context[key];
-				if (value instanceof Array) {
-					context["$" + key] = this._generateArrayAccessorFunc(value);
-				} 
-				if (value instanceof Array || value instanceof Object){
-					this._attachArrayAccessor(value);
-				}
-			}
-		}
-	}
+  /* private */
+  _attachArrayAccessor(context) {
+    for (var key of Object.keys(context)) {
+      if (context.hasOwnProperty(key)) {
+        var value = context[key];
+        if (value instanceof Array) {
+          context['$' + key] = this._generateArrayAccessorFunc(value);
+        } 
+        if (value instanceof Array || value instanceof Object) {
+          this._attachArrayAccessor(value);
+        }
+      }
+    }
+  }
 
-	/* private */
-	_generateArrayAccessorFunc(context) {
-		return function(index) {
-			return context[index];
-		}
-	}
+  /* private */
+  _generateArrayAccessorFunc(context) {
+    return function(index) {
+      return context[index];
+    };
+  }
 
-	/* public */
-	render() {
-		this._attachArrayAccessor(this.context);
-		this._render(this.template)
-	}
+  /* public */
+  render() {
+    this._attachArrayAccessor(this.context);
+    this._render(this.template);
+  }
 
-	/* private */
-	_render(template) {
-		for (var key in template) {
-			if (template.hasOwnProperty(key)) {
-				var value = template[key];
-				if (typeof value === 'string' || value instanceof String) {
-					template[key] = this._replace(template[key]);
-				} else {
-					this._handleConstructs(template, key);
-				}
-			}
-		}
-	}
+  /* private */
+  _render(template) {
+    for (var key of Object.keys(template)) {
+      if (template.hasOwnProperty(key)) {
+        var value = template[key];
+        if (typeof value === 'string' || value instanceof String) {
+          template[key] = this._replace(template[key]);
+        } else {
+          this._handleConstructs(template, key);
+        }
+      }
+    }
+  }
 
-	/* private */
-	_handleConstructs(template, key) {
-		if (template[key]["$if"]) {
-			var condition = template[key]["$if"];
-			var hold = undefined;
-			if (typeof condition === 'string' || condition instanceof String) {
-				//hold = safeEval(condition, this.context);
-				hold = this._replace(condition);
-			} else {
+  /* private */
+  _handleConstructs(template, key) {
+    if (template[key]['$if']) {
+      var condition = template[key]['$if'];
+      var hold = undefined;
+      if (typeof condition === 'string' || condition instanceof String) {
+        //hold = safeEval(condition, this.context);
+        hold = this._replace(condition);
+      } else {
 
-				var err = new Error("invalid construct");
-				err.message = "$if construct must be a string which eval can process";
-				throw err;
-			}
+        var err = new Error('invalid construct');
+        err.message = '$if construct must be a string which eval can process';
+        throw err;
+      }
 
-			if (hold) {
-				var hence = template[key]["$then"];
-				if (typeof hence === 'string' || hence instanceof String) {
-					template[key] = this._replace(hence);
-				} else {
-					this._render(hence);
-					template[key] = hence;
-				}
-			} else {
-				var hence = template[key]["$else"];
-				if (typeof hence === 'string' || hence instanceof String) {
-					template[key] = this._replace(hence);
-				} else {
-					this._render(hence);
-					template[key] = hence;
-				}
-			}
-		} else if (template[key]["$switch"]) {
-			var condition = this._replace(template[key]["$switch"]);
-			var case_option;
-			if (typeof condition === 'string' || condition instanceof String) {
-				case_option = this._replace(condition);
-			} else {
-				var err = new Error("invalid construct");
-				err.message = "$switch construct must be a string which eval can process";
-				throw err;
-			}
-			var case_option_value = template[key][case_option];
-			if (typeof case_option_value === 'string' || case_option_value instanceof String) {
-				template[key] = this._replace(case_option_value);
-			} else {
-				this._render(case_option_value);
-				template[key] = case_option_value;
-			}
-		} else if (template[key]["$eval"]) {
-			var expression = template[key]["$eval"];
-			if (typeof expression === 'string' || expression instanceof String) {
-				template[key] = this._replace(expression);
-			} else {
-				var err = new Error("invalid constructoruct");
-				err.message = "$eval construct must be a string which eval can process";
-				throw err;
-			}
-		} else {
-			this._render(template[key]);
-		}
-	}
+      if (hold) {
+        var hence = template[key]['$then'];
+        if (typeof hence === 'string' || hence instanceof String) {
+          template[key] = this._replace(hence);
+        } else {
+          this._render(hence);
+          template[key] = hence;
+        }
+      } else {
+        var hence = template[key]['$else'];
+        if (typeof hence === 'string' || hence instanceof String) {
+          template[key] = this._replace(hence);
+        } else {
+          this._render(hence);
+          template[key] = hence;
+        }
+      }
+    } else if (template[key]['$switch']) {
+      var condition = this._replace(template[key]['$switch']);
+      var case_option;
+      if (typeof condition === 'string' || condition instanceof String) {
+        case_option = this._replace(condition);
+      } else {
+        var err = new Error('invalid construct');
+        err.message = '$switch construct must be a string which eval can process';
+        throw err;
+      }
+      var case_option_value = template[key][case_option];
+      if (typeof case_option_value === 'string' || case_option_value instanceof String) {
+        template[key] = this._replace(case_option_value);
+      } else {
+        this._render(case_option_value);
+        template[key] = case_option_value;
+      }
+    } else if (template[key]['$eval']) {
+      var expression = template[key]['$eval'];
+      if (typeof expression === 'string' || expression instanceof String) {
+        template[key] = this._replace(expression);
+      } else {
+        var err = new Error('invalid constructoruct');
+        err.message = '$eval construct must be a string which eval can process';
+        throw err;
+      }
+    } else {
+      this._render(template[key]);
+    }
+  }
 
-	/* private */
-	_replace(parameterizedString) {
-		var match = undefined;
-		if (match = this.PARSEEXPR.exec(parameterizedString)) {
-			var replacementValue = safeEval(match[1].trim(), this.context);
-			return parameterizedString.replace(this.PARSEEXPR, replacementValue);
-		} else if (match = this.EXPR.exec(parameterizedString)) {
-			var result = safeEval(match[1].trim(), this.context);
-			return result;	
-		}
-		return parameterizedString;
-	}
+  /* private */
+  _replace(parameterizedString) {
+    var match = undefined;
+    if (match = this.PARSEEXPR.exec(parameterizedString)) {
+      var replacementValue = safeEval(match[1].trim(), this.context);
+      return parameterizedString.replace(this.PARSEEXPR, replacementValue);
+    } else if (match = this.EXPR.exec(parameterizedString)) {
+      var result = safeEval(match[1].trim(), this.context);
+      return result;  
+    }
+    return parameterizedString;
+  }
 
-	/* private */
-	_fetchContextPropertyValue(propertyString) {
-		var propertyString = propertyString.trim();
-		var keys = propertyString.split(".");
-		var result = this.context;
+  /* private */
+  _fetchContextPropertyValue(propertyString) {
+    var propertyString = propertyString.trim();
+    var keys = propertyString.split('.');
+    var result = this.context;
 
-		for (var key in keys) {
-			if (keys.hasOwnProperty(key)) {
-				result = result[keys[key]];
-			}
-		}
+    for (var key of keys) {
+      result = result[key];
+    }
 
-		return result;
-	}
+    return result;
+  }
 
-	/* public */
-	getTemplate() {
-		return this.template;
-	}
+  /* public */
+  getTemplate() {
+    return this.template;
+  }
 
-	/* public */
-	getContext() {
-		return this.context;
-	}
+  /* public */
+  getContext() {
+    return this.context;
+  }
 
-	/* public */
-	setNewTemplate(template) {
-		this.template = _.clone(template);
-	}
+  /* public */
+  setNewTemplate(template) {
+    this.template = _.clone(template);
+  }
 
-	/* public */
-	setNewContext(context) {
-		this.context = context;
-	}
+  /* public */
+  setNewContext(context) {
+    this.context = context;
+  }
 };
 
 //Parameterize.prototype.PARSEEXPR = /{{(\s*([\d\w]+\b.?\b)+\s*)}}/;

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,0 +1,8 @@
+var lint = require('mocha-eslint');
+
+var paths = [
+  'src/*.js',
+  'test/*.js',
+];
+
+lint(paths);

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,6 +1,6 @@
 suite("Parameterize", function() {
 	var assume = require('assume');
-	var Parameterize = require("./index.js");
+	var Parameterize = require("../lib/index.js");
 
 	suite("non deep property access", function () {
     test("with propert access", function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,45 +1,45 @@
-suite("Parameterize", function() {
-	var assume = require('assume');
-	var Parameterize = require("../lib/index.js");
+suite('Parameterize', function() {
+  var assume = require('assume');
+  var Parameterize = require('../lib/index.js');
 
-	suite("non deep property access", function () {
-    test("with propert access", function() {
-      var template = { id: "{{ clientId }}" };
-      var context = { clientId: "123"};
+  suite('non deep property access', function() {
+    test('with propert access', function() {
+      var template = {id: '{{ clientId }}'};
+      var context = {clientId: '123'};
       var engine = new Parameterize(template, context);
       engine.render();
-      assume(engine.getTemplate()).deep.equals({id: "123"});
+      assume(engine.getTemplate()).deep.equals({id: '123'});
     });
 
-    test("with array access", function() {
-      var template = { id: "{{ $arr(0) }}", name: "{{ $arr(2) }}", count: "{{ $arr(1) }}", };
-      var context = {arr: ["123", 248, "doodle"],}
+    test('with array access', function() {
+      var template = {id: '{{ $arr(0) }}', name: '{{ $arr(2) }}', count: '{{ $arr(1) }}'};
+      var context = {arr: ['123', 248, 'doodle']};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({id: "123", name: "doodle", count: "248"}); 
+      assume(par.getTemplate()).deep.equals({id: '123', name: 'doodle', count: '248'}); 
     });
 
-    test("function evaluation", function() {
+    test('function evaluation', function() {
       var template = {
-        name: "{{ func('jim') }}",
-        username: "{{ func(a) }}",
-      }
+        name: '{{ func("jim") }}',
+        username: '{{ func(a) }}',
+      };
       var context = {
-        a: "foobar",
+        a: 'foobar',
         func: function(value) {
           return value;
-        }
-      }
+        },
+      };
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({name: "jim", username: "foobar"});
+      assume(par.getTemplate()).deep.equals({name: 'jim', username: 'foobar'});
     });
 
-    test("Modify string", function() {
+    test('Modify string', function() {
       var template = {
-        key1:     "{{ toUpper( 'hello world') }}",
-        key2:     "{{  toLower(toUpper('hello world'))   }}",
-        key3:     "{{   toLower(  toUpper(  text))  }}",
+        key1:     '{{ toUpper( "hello world") }}',
+        key2:     '{{  toLower(toUpper("hello world"))   }}',
+        key3:     '{{   toLower(  toUpper(  text))  }}',
       };
       var context = {
         toUpper: function(text) {
@@ -48,51 +48,51 @@ suite("Parameterize", function() {
         toLower: function(text) {
           return text.toLowerCase();
         },
-        text: 'hello World'
+        text: 'hello World',
       };
       var output = {
-        key1:     "HELLO WORLD",
-        key2:     "hello world",
-        key3:     "hello world"
+        key1:     'HELLO WORLD',
+        key2:     'hello world',
+        key3:     'hello world',
       };
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals(output)
+      assume(par.getTemplate()).deep.equals(output);
     });
 
-    test("do not evaluate numbers", function() {
+    test('do not evaluate numbers', function() {
       let template = {a: {b: 1}};
-      let context = {}
+      let context = {};
       let par = new Parameterize(template, context);
       par.render();
       assume(par.getTemplate()).deep.equals(template);
     });
 
-    test("do no evaluate simple strings", function() {
-      let template = {a: {b: "1"}};
-      let context = {}
+    test('do no evaluate simple strings', function() {
+      let template = {a: {b: '1'}};
+      let context = {};
       let par = new Parameterize(template, context);
       par.render();
       assume(par.getTemplate()).deep.equals(template);
     });
   });
 
-  suite("deep propert access", function() {
-    test("with deep array access", function() {
-      var template = {image_version: "{{task.$images(0).$versions(0)}}", name: "{{task.$images(0).name}}"};
+  suite('deep propert access', function() {
+    test('with deep array access', function() {
+      var template = {image_version: '{{task.$images(0).$versions(0)}}', name: '{{task.$images(0).name}}'};
       var context = {
         task: {
-          images: [{versions: ["12.10", ], name: "ubuntu"}]
-        }
+          images: [{versions: ['12.10'], name: 'ubuntu'}],
+        },
       };
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({image_version: "12.10", name: "ubuntu"});
+      assume(par.getTemplate()).deep.equals({image_version: '12.10', name: 'ubuntu'});
     });
   });
 
-  suite("non parameterized json template", function() {
-    test("empty template", function() {
+  suite('non parameterized json template', function() {
+    test('empty template', function() {
       var template = {};
       var context = {};
       var par = new Parameterize(template, context);
@@ -100,7 +100,7 @@ suite("Parameterize", function() {
       assume(par.getTemplate()).deep.equals({});
     });
 
-    test("non parameterized template", function() {
+    test('non parameterized template', function() {
       var template = {a: {b: {c: {d: 1}}}};
       var context = {};
       var par = new Parameterize(template, context);
@@ -109,91 +109,90 @@ suite("Parameterize", function() {
     });
   });
 
-
-  suite("constructs", function() {
-    test("if -> then non-deep", function() {
+  suite('constructs', function() {
+    test('if -> then non-deep', function() {
       var template = {
         a: {
-          $if: "${ 1 < 2 }",
-          $then: "a",
-          $else: "b"
-        }
+          $if: '${ 1 < 2 }',
+          $then: 'a',
+          $else: 'b',
+        },
       };
       var context = {};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({a: "a"});
+      assume(par.getTemplate()).deep.equals({a: 'a'});
     });
 
-    test("if -> else non-deep", function() {
+    test('if -> else non-deep', function() {
       var template = {
         a: {
-          $if: "${ 1 > 2 }",
-          $then: "a",
-          $else: "b"
-        }
+          $if: '${ 1 > 2 }',
+          $then: 'a',
+          $else: 'b',
+        },
       };
       var context = {};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({a: "b"});
+      assume(par.getTemplate()).deep.equals({a: 'b'});
     });
 
-    test("if -> then deep", function() {
+    test('if -> then deep', function() {
       var template = {
         b: {a: {
-          $if: "${ 1 < 2 }",
-          $then: "a",
-          $else: "b"
-        }}
+          $if: '${ 1 < 2 }',
+          $then: 'a',
+          $else: 'b',
+        }},
       };
       var context = {};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({b : {a: "a"}});
+      assume(par.getTemplate()).deep.equals({b : {a: 'a'}});
     });
 
-    test("if -> else deep", function() {
+    test('if -> else deep', function() {
       var template = {
         b: {a: {
-          $if: "${ 1 > 2 }",
-          $then: "a",
-          $else: "b"
-        }}
+          $if: '${ 1 > 2 }',
+          $then: 'a',
+          $else: 'b',
+        }},
       };
       var context = {};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({b: {a: "b"}});
+      assume(par.getTemplate()).deep.equals({b: {a: 'b'}});
     });
 
-    test("switch with only one option", function() {
+    test('switch with only one option', function() {
       var template = {
         a: {
-          $switch: "{{ 'case' + a }}",
-          case1: "foo"
+          $switch: '{{ "case" + a }}',
+          case1: 'foo',
         }};
-      var context = {a: "1"};
+      var context = {a: '1'};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({a: "foo"});
+      assume(par.getTemplate()).deep.equals({a: 'foo'});
     });
 
-    test("switch with multiple options", function() {
+    test('switch with multiple options', function() {
       var template = {
         a: {
-          $switch: "{{ 'case' + b }}",
-          case1: "foo",
-          case2: "bar"
+          $switch: '{{ "case" + b }}',
+          case1: 'foo',
+          case2: 'bar',
         }};
-      var context = {a: "1", b: "2"};
+      var context = {a: '1', b: '2'};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({a: "bar"});
+      assume(par.getTemplate()).deep.equals({a: 'bar'});
     });
 
-    test("eval with multiple function evaluations", function() {
-        var template = {
+    test('eval with multiple function evaluations', function() {
+      var template = {
         value: [
           {$eval: '${ func(0) }'},
           {$eval: '${ func(0) }'},
@@ -204,212 +203,224 @@ suite("Parameterize", function() {
           {$eval: '${ func(0) }'},
           {$eval: '${ func(0) }'},
           {$eval: '${ func(0) }'},
-          {$eval: '${ func(1+1) }'}
-        ]
+          {$eval: '${ func(1+1) }'},
+        ],
       };
       var i = 0;
       var context = {
-      'func':  function(x) { i += 1; return x + i; }
+        func:  function(x) { i += 1; return x + i; },
       };
       var output = {
-        value: [1, 2, 2, 2, 5, 6, 7, 8, 9, 12]
+        value: [1, 2, 2, 2, 5, 6, 7, 8, 9, 12],
       };
       var par = new Parameterize(template, context);
       par.render();
       assume(par.getTemplate()).deep.equals(output);
     });
 
-    test("nested if (then --> then) construct", function() {
+    test('nested if (then --> then) construct', function() {
       var template = {
         val: {
-          $if: "${ key1 > key2 }",
+          $if: '${ key1 > key2 }',
           $then: {
             b: {
-              $if: "${ key3 > key4 }",
-              $then: "{{ foo }}",
-              $else: "{{ bar }}"
-            }
+              $if: '${ key3 > key4 }',
+              $then: '{{ foo }}',
+              $else: '{{ bar }}',
+            },
           },
-          $else: {b: "failed"}
-        }
+          $else: {b: 'failed'},
+        },
       };
 
-      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: "a", bar: "b"};
+      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: 'a', bar: 'b'};
 
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({val: {b: "a"}});
+      assume(par.getTemplate()).deep.equals({val: {b: 'a'}});
     });
 
-    test("nested if (else --> else) construct", function() {
+    test('nested if (else --> else) construct', function() {
       var template = {
         val: {
-          $if: "${ key1 < key2 }",
+          $if: '${ key1 < key2 }',
           $else: {
             b: {
-              $if: "${ key3 < key4 }",
-              $then: "{{ foo }}",
-              $else: "{{ bar }}"
-            }
+              $if: '${ key3 < key4 }',
+              $then: '{{ foo }}',
+              $else: '{{ bar }}',
+            },
           },
-          $then: {b: "failed"}
-        }
+          $then: {b: 'failed'},
+        },
       };
 
-      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: "a", bar: "b"};
+      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: 'a', bar: 'b'};
 
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({val: {b: "b"}});
+      assume(par.getTemplate()).deep.equals({val: {b: 'b'}});
     });
 
-    test("nested if (then --> else) construct", function() {
+    test('nested if (then --> else) construct', function() {
       var template = {
         val: {
-          $if: "${ key1 > key2 }",
+          $if: '${ key1 > key2 }',
           $then: {
             b: {
-              $if: "${ key3 < key4 }",
-              $then: "{{ foo }}",
-              $else: "{{ bar }}"
-            }
+              $if: '${ key3 < key4 }',
+              $then: '{{ foo }}',
+              $else: '{{ bar }}',
+            },
           },
-          $else: {b: "failed"}
-        }
+          $else: {b: 'failed'},
+        },
       };
 
-      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: "a", bar: "b"};
+      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: 'a', bar: 'b'};
 
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({val: {b: "b"}});
+      assume(par.getTemplate()).deep.equals({val: {b: 'b'}});
     });
 
-    test("nested if (else --> then) construct", function() {
+    test('nested if (else --> then) construct', function() {
       var template = {
         val: {
-          $if: "${ key1 < key2 }",
+          $if: '${ key1 < key2 }',
           $else: {
             b: {
-              $if: "${ key3 > key4 }",
-              $then: "{{ foo }}",
-              $else: "{{ bar }}"
-            }
+              $if: '${ key3 > key4 }',
+              $then: '{{ foo }}',
+              $else: '{{ bar }}',
+            },
           },
-          $then: {b: "failed"}
-        }
+          $then: {b: 'failed'},
+        },
       };
 
-      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: "a", bar: "b"};
+      var context = {key1: 2, key2: 1, key3: 4, key4: 3, foo: 'a', bar: 'b'};
 
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({val: {b: "a"}});
+      assume(par.getTemplate()).deep.equals({val: {b: 'a'}});
     });
 
-    test("nested if (else --> then ---> else) construct", function() {
+    test('nested if (else --> then ---> else) construct', function() {
       var template = {
         val: {
-          $if: "${ key1 < key2 }",
+          $if: '${ key1 < key2 }',
           $else: {
             b: {
-              $if: "${ key3 > key4 }",
+              $if: '${ key3 > key4 }',
               $then: {
                 c: {
-                  $if: "${ key5 < key6 }",
-                  $then: "abc",
-                  $else: "{{ bar }}"
-                }
+                  $if: '${ key5 < key6 }',
+                  $then: 'abc',
+                  $else: '{{ bar }}',
+                },
               },
-              $else: "follow"
-            }
+              $else: 'follow',
+            },
           },
-          $then: {b: "failed"}
-        }
+          $then: {b: 'failed'},
+        },
       };
 
-      var context = {key1: 2, key2: 1, key3: 4, key4: 3, key5: 6, key6: 5, foo: "a", bar: "b"};
+      var context = {key1: 2, key2: 1, key3: 4, key4: 3, key5: 6, key6: 5, foo: 'a', bar: 'b'};
 
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({val: {b: {c: "b"}}});
+      assume(par.getTemplate()).deep.equals({val: {b: {c: 'b'}}});
     });
 
-    test("if ($then) with ${ expression }", function() {
+    test('if ($then) with ${ expression }', function() {
       var template = {
         a: {
           b: {
-            $if: "${ 2 < 3 }",
-            $then: "${ one() }",
-            $else: "${ two() }"
+            $if: '${ 2 < 3 }',
+            $then: '${ one() }',
+            $else: '${ two() }',
           }}};
-      var context = {one: function() {return 1}, two: function() {return 2;}}
+      var context = {
+        one: () => 1,
+        two: () => 2,
+      };
       var par = new Parameterize(template, context);
       par.render();
       assume(par.getTemplate()).deep.equals({a:{b:1}});
     });
 
-    test("if (else) with ${ expression }", function() {
+    test('if (else) with ${ expression }', function() {
       var template = {
         a: {
           b: {
-            $if: "${ 2 < 3 }",
-            $then: "${ one() }",
-            $else: "${ two() }"
+            $if: '${ 2 < 3 }',
+            $then: '${ one() }',
+            $else: '${ two() }',
           }}};
-      var context = {one: function() {return 1}, two: function() {return 2;}}
+      var context = {
+        one: () => 1,
+        two: () => 2,
+      };
       var par = new Parameterize(template, context);
       par.render();
       assume(par.getTemplate()).deep.equals({a:{b:1}});
     });
 
-    test("simple $eval with simple value", function() {
-      var template = {a: {b: {$eval: "1"}}};
-      var context = {one: function() {return 1}, two: function() {return 2;}}
+    test('simple $eval with simple value', function() {
+      var template = {a: {b: {$eval: '1'}}};
+      var context = {
+        one: () => 1,
+        two: () => 2,
+      };
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({a:{b:"1"}});
+      assume(par.getTemplate()).deep.equals({a:{b:'1'}});
     });
 
-    test("simple $eval with ${ expression }", function() {
-      var template = {a: {b: {$eval: "${ one() }"}}};
-      var context = {one: function() {return 1}, two: function() {return 2;}}
+    test('simple $eval with ${ expression }', function() {
+      var template = {a: {b: {$eval: '${ one() }'}}};
+      var context = {
+        one: () => 1,
+        two: () => 2,
+      };
       var par = new Parameterize(template, context);
       par.render();
       assume(par.getTemplate()).deep.equals({a:{b:1}});
     });
 
-    test("switch case where case is an object", function() {
+    test('switch case where case is an object', function() {
       var template = {
         a: {
-          $switch: "{{ 'case' + a }}",
-          caseA: {b:1}
+          $switch: '{{ "case" + a }}',
+          caseA: {b:1},
         }};
-      var context = {a: "A"};
+      var context = {a: 'A'};
       var par = new Parameterize(template, context);
       par.render();
       assume(par.getTemplate()).deep.equals({a: {b: 1}});
     });
 
-    test("switch case where case is an eval statement", function() {
+    test('switch case where case is an eval statement', function() {
       var template = {
         a: {
-          $switch: "{{ 'case' + a }}",
-          caseA: "${ a }"
+          $switch: '{{ "case" + a }}',
+          caseA: '${ a }',
         }};
-      var context = {a: "A"};
+      var context = {a: 'A'};
       var par = new Parameterize(template, context);
       par.render();
-      assume(par.getTemplate()).deep.equals({a: "A"});
+      assume(par.getTemplate()).deep.equals({a: 'A'});
     });
   });
 
-  suite("interface tests", function() {
+  suite('interface tests', function() {
 
-    test("template get/set methods", function() {
-      var c1 = {a: {foo: "bar"}};
-      var c2 = {a: {b: "c"}};
-      var c3 = {d: {e: "f"}};
+    test('template get/set methods', function() {
+      var c1 = {a: {foo: 'bar'}};
+      var c2 = {a: {b: 'c'}};
+      var c3 = {d: {e: 'f'}};
       
       var par = new Parameterize(c1, {});
       assume(par.getTemplate()).deep.equals(c1);
@@ -424,10 +435,10 @@ suite("Parameterize", function() {
       assume(par.getTemplate()).deep.equals(c3);
     });
 
-    test("context get/set methods", function() {
-      var c1 = {a: {foo: "bar"}};
-      var c2 = {a: {b: "c"}};
-      var c3 = {d: {e: "f"}};
+    test('context get/set methods', function() {
+      var c1 = {a: {foo: 'bar'}};
+      var c2 = {a: {b: 'c'}};
+      var c3 = {d: {e: 'f'}};
       
       var par = new Parameterize({}, c1);
       assume(par.getContext()).deep.equals(c1);


### PR DESCRIPTION
The first of these commits uses `babel-compile`, but sticks with the `babel-preset-es2015` -- that's pretty close to `babel-preset-taskcluster` anyway.

The second commit enables eslint, using the taskcluster eslint preset.  This generates a lot of warnings!  In general, I find it easier to work with one set of eslint configs for all of the TC-related projects, so that's my argument for merging this PR.  However, this is your project so if you don't like these settings then it's entirely OK to say "no" to the whole commit, or to suggest a different eslint preset.  Since I don't know what your decision will be, I haven't modified `src/index.js` to fix the warnings, but I will do that before you merge this PR.

Let me know what you would prefer.